### PR TITLE
Gracefully handle files without any float grids

### DIFF
--- a/DendroAPI/DendroGrid.cpp
+++ b/DendroAPI/DendroGrid.cpp
@@ -46,6 +46,9 @@ bool DendroGrid::Read(const char * vFile)
 	}
 
 	mGrid = openvdb::gridPtrCast<openvdb::FloatGrid>(file.readGrid(nameIter.gridName()));
+	if (mGrid == nullptr) {
+		return false;
+	}
 
 	return true;
 }

--- a/DendroGH/Classes/DendroVolume.cs
+++ b/DendroGH/Classes/DendroVolume.cs
@@ -25,7 +25,7 @@ namespace DendroGH {
         static private extern IntPtr DendroDuplicate (IntPtr grid);
 
         [DllImport ("DendroAPI.dll", CallingConvention = CallingConvention.Cdecl)]
-        static private extern bool DendroRead (IntPtr grid, string filename);
+        static private extern byte DendroRead (IntPtr grid, string filename);
 
         [DllImport ("DendroAPI.dll", CallingConvention = CallingConvention.Cdecl)]
         static private extern bool DendroWrite (IntPtr grid, string filename);
@@ -279,7 +279,7 @@ namespace DendroGH {
             }
 
             // pinvoke file read function
-            this.IsValid = DendroRead (this.Grid, vFile);
+            this.IsValid = DendroRead (this.Grid, vFile) == 1;
 
             if (!this.IsValid) {
                 return false;


### PR DESCRIPTION
Dendro only supports reading float grids from a VDB file, so if it cannot read any float grid from a file,
return false. Then in the P/Invoke DendroRead function, return a `byte` type, as a workaround for returning a boolean following https://learn.microsoft.com/en-us/dotnet/framework/interop/blittable-and-non-blittable-types and
https://stackoverflow.com/a/20037067, so the failure to read a grid from a file is handled more gracefully.